### PR TITLE
Adding dependency version checker

### DIFF
--- a/bin/wt-bundle
+++ b/bin/wt-bundle
@@ -2,6 +2,7 @@
 
 var ArgumentParser = require('argparse').ArgumentParser;
 var Bundler = require('../');
+var Checker = require('../checker.js');
 var Fs = require('fs');
 var Mkdirp = require('mkdirp');
 var Package = require('../package.json');
@@ -66,11 +67,51 @@ parser.addArgument(
 );
 
 
+var subparsers = parser.addSubparsers({
+    title: 'modules',
+    dest:  'modules'
+});
+
+subparsers.addParser('check', {
+    help: 'Check the version of each module against webtask.io'
+});
+
+subparsers.addParser('sync', {
+    help: 'Recreate "package.json" using webtask.io compatible version of each module'
+})
+.addArgument(
+    ['-i'],
+    {
+        help: 'Ask on every module ',
+        action: 'storeTrue',
+        dest: 'interactive'
+    }
+);
 
 var args = parser.parseArgs();
 
 if (args.watch && !args.output) {
     return exitError('An `ouput` path is required when `watch` is enabled', { showHelp: true });
+}
+
+if (args.modules === 'check') {
+    var $check = Checker.check({
+        entry: Path.resolve(process.cwd())
+    });
+    $check.subscribe(function () {}, onError, onComplete);
+
+    return;
+}
+
+if (args.modules === 'sync') {
+    var $sync = Checker.sync({
+        entry: Path.resolve(process.cwd()),
+        interactive: args.interactive
+    });
+
+    $sync.subscribe(function () {}, onError, onComplete);
+
+    return;
 }
 
 var bundle$ = Bundler.bundle({
@@ -93,17 +134,17 @@ function onNext(build) {
         if (args.watch) {
             console.log('Successfully built code at generation %d', build.generation);
         }
-        
+
         Mkdirp(Path.dirname(args.output), function (err) {
             if (err) {
                 return exitError('Error creating the output directory: ' + err.message);
             }
-            
+
             Fs.writeFile(args.output, build.code, 'utf8', function (err) {
                 if (err) {
                     return exitError('Error writing output to `' + Path.basename(args.output) + '`: ' + err.message);
                 }
-                
+
                 console.log('Bundle successfully written to `%s`', args.output);
             });
         });
@@ -121,16 +162,16 @@ function onComplete() {
 
 function exitError(message, options) {
     if (!options) options = {};
-    
+
     var exitCode = typeof options.exitCode === 'undefined'
         ?   1
         :   options.exitCode;
-    
+
     console.error(message);
-    
+
     if (options.showHelp) {
         Argv.help();
     }
-    
+
     process.exit(exitCode);
 }

--- a/checker.js
+++ b/checker.js
@@ -1,0 +1,176 @@
+var fs         = require('fs')
+var Table      = require('cli-table');
+var colors     = require('colors');
+var path       = require('path');
+var Superagent = require('superagent');
+var readline   = require('readline-sync');
+var helpers    = require('./helpers');
+var semver     = require('semver');
+var _          = require('lodash');
+var Rx         = require('rxjs');
+
+var LIST_MODULES_URL = 'https://webtask.it.auth0.com/api/run/wt-tehsis-gmail_com-1?key=eyJhbGciOiJIUzI1NiIsImtpZCI6IjIifQ.eyJqdGkiOiJmZGZiOWU2MjQ0YjQ0YWYyYjc2YzAwNGU1NjgwOGIxNCIsImlhdCI6MTQzMDMyNjc4MiwiY2EiOlsiZDQ3ZDNiMzRkMmI3NGEwZDljYzgwOTg3OGQ3MWQ4Y2QiXSwiZGQiOjAsInVybCI6Imh0dHA6Ly90ZWhzaXMuZ2l0aHViLmlvL3dlYnRhc2tpby1jYW5pcmVxdWlyZS90YXNrcy9saXN0X21vZHVsZXMuanMiLCJ0ZW4iOiIvXnd0LXRlaHNpcy1nbWFpbF9jb20tWzAtMV0kLyJ9.MJqAB9mgs57tQTWtRuZRj6NCbzXxZcXCASYGISk3Q6c';
+
+module.exports.check = check;
+module.exports.sync  = sync;
+
+function checkVersion(local, webtask) {
+    var flag = true;
+
+    if (webtask !== '-') {
+        flag = semver.ltr(webtask, local);
+    }
+
+    return flag;
+}
+
+function findByName (key) {
+    return function (el) {
+        return el.name === key;
+    }
+}
+
+function findByNameAndVersion (key, localVersion) {
+    return function (el) {
+        return el.name === key &&  el.version === localVersion;
+    }
+}
+
+function format(str, length) {
+    var strLength = str.length;
+
+    for(var i = 0; i < (length-strLength); i++) {
+        str = str + ' ';
+    }
+
+    return str;
+}
+
+function sync(opt) {
+    return Rx.Observable.create(function (subscriber) {
+        var pkg = helpers.getPackageJsonPath(opt.entry);
+
+        try {
+            fs.statSync(pkg);
+        }
+        catch (err) {
+            console.log('\n-> "package.json" does not exists\n'.red);
+            subscriber.error(err);
+        }
+
+        try {
+            console.log('\n-> Copying "package.json" to "package.json.orig"\n');
+            fs.createReadStream(pkg).pipe(fs.createWriteStream(path.join(process.cwd(), 'package.json.orig')));
+        }
+        catch (err) {
+            console.log('\n-> Error trying to copy "package.json"\n'.red);
+            subscriber.error(err);
+        }
+
+        Superagent.get(LIST_MODULES_URL)
+            .end(function (err, res) {
+                if (err) {
+                    console.log('\n-> Error loading modules from webtask.io\n'.red);
+                    subscriber.error(err);
+                }
+
+                var package   = JSON.parse(fs.readFileSync(pkg).toString());
+                var libraries = res.body;
+
+                Object.keys(package.dependencies).forEach(function (key) {
+                    var wtLib        = libraries.modules.filter(findByName(key)).reverse().pop();
+                    var localVersion = package.dependencies[key];
+
+                    if (wtLib && wtLib.version !== localVersion) {
+                        if (opt.interactive) {
+                            var value = readline.keyInYN('->'.blue + ' Do you want to modify ' + key.green + ' from '+ ('v' + localVersion).green +' to ' + ('v' + wtLib.version).green + '?');
+
+                            if (value) {
+                                package.dependencies[key] = wtLib.version;
+                            }
+                        } else {
+                            console.log('->'.blue + ' Updating %s from %s to %s', format(key, 25).green, format(localVersion, 8).green, format(wtLib.version, 8).green);
+                            package.dependencies[key] = wtLib.version;
+                        }
+                    }
+                });
+
+                try {
+                    fs.writeFileSync(pkg, JSON.stringify(package, null, 2));
+                    console.log('\n-> "package.json" updated successfully\n'.green);
+                    subscriber.complete();
+                }
+                catch (err) {
+                    console.log(err);
+                    console.log('\n-> Error updating "package.json"\n'.red);
+                    subscriber.error(err);
+                }
+            });
+    });
+}
+
+function check(opt) {
+    return Rx.Observable.create(function (subscriber) {
+        var pkg = helpers.getPackageJsonPath(opt.entry);
+
+        var table = new Table({
+            head: ['', 'Dependency', 'Version', 'Available version'],
+            colWidths: [3, 30, 20, 20],
+            style : {compact : true, head: ['white']}
+        });
+
+        try {
+            fs.statSync(pkg);
+        }
+        catch (err) {
+            console.log('\n-> "package.json" does not exists\n'.red);
+            subscriber.error(err);
+        }
+
+        Superagent.get(LIST_MODULES_URL)
+            .end(function (err, res) {
+                if (err) {
+                    console.log('\n-> Error loading modules from webtask.io\n'.red);
+                    subscriber.error(err);
+                }
+
+                var libraries    = res.body;
+                var package      = JSON.parse(fs.readFileSync(pkg).toString());
+                var dependencies = package.dependencies;
+                var isCompliant  = true;
+
+                if (dependencies) {
+                    Object.keys(dependencies).forEach(function (key) {
+                        var localVersion = dependencies[key];
+                        var lib          = _.find(libraries.modules, _.matches({name: key, version: localVersion}));
+
+                        lib = lib || _.find(libraries.modules, _.matchesProperty('name', key)) || {version: '-'};
+
+                        var flag    = checkVersion(localVersion, lib.version);
+                        var color   = flag ? 'red' : 'green';
+                        var diff    = flag ? '\u25A0'.red : '\u25A0'.green;
+                        var element = {};
+
+                        element[diff] = [key[color], localVersion[color], lib.version[color]];
+
+                        table.push(element);
+
+                        isCompliant = isCompliant && !flag;
+                    });
+
+                    console.log();
+                    console.log(table.toString());
+
+                    if (isCompliant) {
+                        console.log('\n-> Your library is compliant with Webtask.io\n'.green);
+                    } else {
+                        console.log('\n-> By requiring different versions than webtask.io you\'ll have heavier bundles.\n'.white);
+                    }
+                } else {
+                    console.log('\n-> "package.json" does not have dependencies to check\n'.yellow)
+                }
+
+                subscriber.complete();
+            });
+    });
+}

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,31 @@
+var Path = require('path');
+
+function getDirname (entry) {
+    var segments = Path.dirname(Path.normalize(entry))
+        .split(Path.sep)
+        .filter(Boolean);
+
+    while (segments.length) {
+        try {
+            var pathname = Path.sep + Path.join.apply(null, segments.concat(['package.json']));
+
+            // When require doesn't throw, we break out of the loop
+            require(pathname);
+
+            break;
+        } catch (__) { }
+
+        segments.pop();
+    }
+
+    return segments.length
+        ?   Path.resolve(Path.sep + Path.join.apply(null, segments))
+        :   process.cwd();
+}
+
+function getPackageJsonPath(entry) {
+    return Path.join(getDirname(entry), 'package.json');
+}
+
+module.exports.getDirname         = getDirname;
+module.exports.getPackageJsonPath = getPackageJsonPath;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-bundle",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Bundle your webtask scripts",
   "main": "index.js",
   "bin": {
@@ -14,18 +14,21 @@
   ],
   "author": "Geoff Goodman",
   "license": "MIT",
-  "dependencies": {
+   "dependencies": {
     "argparse": "^1.0.5",
     "babel-core": "^6.5.1",
     "babel-loader": "^6.2.2",
     "babel-plugin-transform-runtime": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-runtime": "^6.5.0",
+    "cli-table": "^0.3.1",
+    "colors": "^1.1.2",
     "glob": "^6.0.4",
     "lodash": "^3.10.1",
     "memory-fs": "^0.3.0",
     "mkdirp": "^0.5.1",
     "raw-loader": "^0.5.1",
+    "readline-sync": "^1.3.1",
     "rxjs": "^5.0.0-beta.2",
     "semver": "^5.1.0",
     "superagent": "^1.7.2",


### PR DESCRIPTION
This PR adds new functionalities to sync/check modules against available modules on webtask.io.

#### `wt-bundle modules check`

This option allows you to check if the required modules by your app are available on webtask.io. 

<img width="836" alt="screen shot 2016-02-11 at 8 59 16 pm" src="https://cloud.githubusercontent.com/assets/302314/12995009/e7777084-d102-11e5-9c75-59777d96c7c3.png">

#### `wt-bundle modules sync`

This option allows you to sync your `package.json` with the available version of each module on webtask.io. It will take the latest version of each module.

<img width="834" alt="screen shot 2016-02-11 at 9 00 24 pm" src="https://cloud.githubusercontent.com/assets/302314/12995010/e7a6b358-d102-11e5-92d7-47a91a4369c5.png">

#### `wt-bundle modules sync -i`

Same as `sync` but asking for each module.

<img width="834" alt="screen shot 2016-02-11 at 9 00 57 pm" src="https://cloud.githubusercontent.com/assets/302314/12995011/e7c237cc-d102-11e5-8baa-fd6f51c3aa19.png">