### PR TITLE
Add more verbose output to Webpack and fail on error.

### DIFF
--- a/lib/configureWebpack.js
+++ b/lib/configureWebpack.js
@@ -13,6 +13,7 @@ function configureWebpack(options) {
     entry[options.name] = options.entry;
     
     const config = {
+        bail: true,
         entry: entry,
         output: {
             path: '/',


### PR DESCRIPTION
If creating the new webtask will fail on bundling stage then it prints out `Bundling failed` message. To improve it and print the full stack trace to get more insight into the reason why Webpack failed we need to add `bail` parameter.

ref: https://webpack.github.io/docs/configuration.html#bail