### PR TITLE
Support longer require syntax 'require("module@version")'

### DIFF
--- a/lib/calculateExternalsLoose.js
+++ b/lib/calculateExternalsLoose.js
@@ -28,7 +28,15 @@ function buildContext(modules, cb) {
     
     Object.keys(modules.native)
         .concat(Object.keys(modules.installed))
-        .forEach(name => context.externals[name] = true);
+        .forEach(name => {
+            context.externals[name] = true
+            //support 'modulename@version' syntax
+            if(modules.installed[name]) {
+                modules.installed[name].forEach((version) => {
+                    context.externals[name + '@' + version] = true;
+                })
+            }
+        });
     
     cb(null, context);
 }


### PR DESCRIPTION
I added a bit of code in the that lets scripts use the extended require syntax in non-strict mode. #12 
