### PR TITLE
Swap production mode implicit config for explicit uglifyjs config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Path = require('path');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
     create,
@@ -85,7 +86,12 @@ function create(options) {
                 },
             ],
         },
-        plugins: [],
+        plugins: options.minify ? [new UglifyJsPlugin({
+            extractComments: {
+                condition: 'all',
+                banner: false,
+            },
+        })] : [],
         resolve: {
             modules: [Path.join(process.cwd(), 'node_modules')],
             mainFields: ['module', 'main'],
@@ -95,7 +101,7 @@ function create(options) {
             // moduleExtensions: ['', '.webpack-loader.js', '.web-loader.js', '.loader.js', '.js'],
             mainFields: ['webpackLoader', 'loader', 'module', 'main'],
         },
-        mode: options.minify ? 'production' : 'development',
+        mode: 'development',
         devtool: false,
         node: {
             console: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-bundle",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Bundle your webtask scripts",
   "main": "index.js",
   "bin": {
@@ -30,6 +30,7 @@
     "mkdirp": "^0.5.1",
     "raw-loader": "^0.5.1",
     "rxjs": "^5.5.10",
+    "uglifyjs-webpack-plugin": "^1.3.0",
     "webpack": "^4.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Context:
---
https://github.com/auth0/wt-cli/issues/227

Creating a webtask using the CLI and passing `--bundle-minify` causes it to break. Invoking the webtask returns:
```
{
  "code": 400,
  "message": "Invalid webtask code",
  "error": "Supplied code must return or export a function."
}
```
 Creating a webtask with just `--bundle` does not cause it to break. It is specifically related to the minify process. The issue is also independent of the CLI as the process can be reproduced just using the `webtask-bundler` and pasting the output into a webtask.

Minifying a webtask simply results in the webpack configuration being set to `production` mode:
https://github.com/auth0/webtask-bundle/blob/0f74ddc87a83dd820d2152d36df66fe24341cea0/lib/config.js#L98

As you can see [here in the documentation](https://webpack.js.org/concepts/mode/#usage), providing the mode configuration option tells webpack to use its built-in optimizations accordingly. The fact that different plugins are used in either `production` or `development` mode explains why using `--bundle-minify` causes the error.

Solution:
---
`uglifyjs-webpack-plugin` is used by `webpack` and was already being included in the project as a child dependency. It is now being included in the `package.json` and required at the top of the config file. Instead of using the implicit configuration provided by `production` mode, we will use the same mode by default (`development`) and explicitly configure the uglify plugin in a way that does not break our webtasks.

Example Output:
---
#### Bundled & Minified
```javascript
const webtaskApi = module.webtask;
module.exports=function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}return r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,"a",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p="/build/",r(r.s="./test.js")}({"./foo.js":function(e,t,r){"use strict";r.r(t),r.d(t,"Foo",function(){return n}),(e=e||{}).webtask=webtaskApi;class n{}},"./test.js":function(e,t,r){"use strict";r.r(t);var n=r("./foo.js");(e=e||{}).webtask=webtaskApi,e.exports=function(e,t){t(null,new n.Foo)}}});
```