### PR TITLE
Add support for opting out of babel transpilation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,30 @@ function create(options) {
     const dependencies = options.dependencies || {};
     const isBareModuleRx = /^(?![./\\]|[a-zA-Z]:)/;
     const moduleSpecRx = /^((?:@[^/]+\/)?[^/]+)/;
+    const useBabel = !options.disableTranspilation;
+
+    const jsLoaders = [
+        {
+            options: {
+                'module.webtask': '>webtaskApi',
+            },
+            loader: require.resolve('imports-loader'),
+        },
+    ];
+
+    if (useBabel) {
+        jsLoaders.push({
+            options: {
+                presets: [[require.resolve('@babel/preset-env'), {
+                    targets: {
+                        node: options.nodeVersion || '4',
+                    },
+                    useBuiltIns: 'usage',
+                }]],
+            },
+            loader: require.resolve('babel-loader'),
+        });
+    }
 
     const config = {
         entry: {
@@ -53,25 +77,7 @@ function create(options) {
                         test: /\.jsx?$/,
                         exclude: /node_modules/,
                     },
-                    use: [
-                        {
-                            options: {
-                                'module.webtask': '>webtaskApi',
-                            },
-                            loader: require.resolve('imports-loader'),
-                        },
-                        {
-                            options: {
-                                presets: [[require.resolve('@babel/preset-env'), {
-                                    targets: {
-                                        node: options.nodeVersion || '4',
-                                    },
-                                    useBuiltIns: 'usage',
-                                }]],
-                            },
-                            loader: require.resolve('babel-loader'),
-                        },
-                    ],
+                    use: jsLoaders,
                 },
                 {
                     issuer: {


### PR DESCRIPTION
## Description

Now that most Webtask runtime versions support all of the language features that babel historically targeted, some use-cases no longer want to transpile modules with babel.

This PR introduces a new `disableTranspilation` option to opt out of `@babel/preset-env`.